### PR TITLE
fingerprint: add tracing support

### DIFF
--- a/podfingerprint.go
+++ b/podfingerprint.go
@@ -87,11 +87,23 @@ type Fingerprint struct {
 // The size parameter is a hint for the expected size of the pod set. Use 0 if you don't know.
 // Values of size < 0 are ignored.
 func NewFingerprint(size int) *Fingerprint {
+	fp := &Fingerprint{}
+	fp.Reset(size)
+	return fp
+}
+
+// Reset clears the internal state of the Fingerprint to empty (pristine) state.
+// The size parameter is a hint for the expected size of the pod set. Use 0 if you don't know.
+// Values of size < 0 are ignored.
+// Explicit usage of this function is not recommended. Client code should not recycle Fingerprint
+// objects, but rather discarded them after they are used - even though calling multiple times
+// Sign() or Check() once reached steady state is perfectly fine.
+func (fp *Fingerprint) Reset(size int) {
 	data := []uint64{}
 	if size > 0 {
 		data = make([]uint64, 0, size)
 	}
-	return &Fingerprint{hashes: data}
+	fp.hashes = data
 }
 
 // AddPod adds a pod to the pod set.
@@ -124,7 +136,8 @@ func (fp *Fingerprint) Sum() []byte {
 // The string should be considered a opaque identifier and checked only for
 // equality, or fed into Check
 func (fp *Fingerprint) Sign() string {
-	return Prefix + Version + hex.EncodeToString(fp.Sum())
+	sign := Prefix + Version + hex.EncodeToString(fp.Sum())
+	return sign
 }
 
 // Check verifies if the provided fingerprint matches the current pod set.

--- a/podfingerprint_test.go
+++ b/podfingerprint_test.go
@@ -27,22 +27,9 @@ import (
 	"testing"
 )
 
-type podIdent struct {
-	Namespace string
-	Name      string
-}
+var stressPods []NamespacedName
 
-func (pi podIdent) GetNamespace() string {
-	return pi.Namespace
-}
-
-func (pi podIdent) GetName() string {
-	return pi.Name
-}
-
-var stressPods []podIdent
-
-var pods []podIdent
+var pods []NamespacedName
 var podsErr error
 
 const (
@@ -75,7 +62,7 @@ func init() {
 
 	stressPodsCount := clusterMaxNodes * clusterMaxPodsPerNode
 	for idx := 0; idx < stressPodsCount; idx++ {
-		stressPods = append(stressPods, podIdent{
+		stressPods = append(stressPods, NamespacedName{
 			Namespace: RandStringBytes(stressNamespaceLen),
 			Name:      RandStringBytes(stressNameLen),
 		})
@@ -145,17 +132,17 @@ func TestSumPodStable(t *testing.T) {
 		t.Fatalf("cannot load the test data: %v", podsErr)
 	}
 
-	localPods := make([]podIdent, len(pods))
+	localPods := make([]NamespacedName, len(pods))
 	copy(localPods, pods)
 	rand.Shuffle(len(localPods), func(i, j int) {
 		localPods[i], localPods[j] = localPods[j], localPods[i]
 	})
 
-	fp := &Fingerprint{}
+	fp := NewFingerprint(0)
 	for _, pod := range pods {
 		fp.AddPod(&pod)
 	}
-	fp2 := &Fingerprint{}
+	fp2 := NewFingerprint(0)
 	for _, localPod := range localPods {
 		fp2.Add(localPod.Namespace, localPod.Name)
 	}
@@ -187,17 +174,17 @@ func TestSumStable(t *testing.T) {
 		t.Fatalf("cannot load the test data: %v", podsErr)
 	}
 
-	localPods := make([]podIdent, len(pods))
+	localPods := make([]NamespacedName, len(pods))
 	copy(localPods, pods)
 	rand.Shuffle(len(localPods), func(i, j int) {
 		localPods[i], localPods[j] = localPods[j], localPods[i]
 	})
 
-	fp := &Fingerprint{}
+	fp := NewFingerprint(0)
 	for _, pod := range pods {
 		fp.Add(pod.Namespace, pod.Name)
 	}
-	fp2 := &Fingerprint{}
+	fp2 := NewFingerprint(0)
 	for _, localPod := range localPods {
 		fp2.Add(localPod.Namespace, localPod.Name)
 	}
@@ -214,17 +201,17 @@ func TestSign(t *testing.T) {
 		t.Fatalf("cannot load the test data: %v", podsErr)
 	}
 
-	localPods := make([]podIdent, len(pods))
+	localPods := make([]NamespacedName, len(pods))
 	copy(localPods, pods)
 	rand.Shuffle(len(localPods), func(i, j int) {
 		localPods[i], localPods[j] = localPods[j], localPods[i]
 	})
 
-	fp := &Fingerprint{}
+	fp := NewFingerprint(0)
 	for _, pod := range pods {
 		fp.Add(pod.Namespace, pod.Name)
 	}
-	fp2 := &Fingerprint{}
+	fp2 := NewFingerprint(0)
 	for _, localPod := range localPods {
 		fp2.Add(localPod.Namespace, localPod.Name)
 	}
@@ -239,7 +226,7 @@ func TestSign(t *testing.T) {
 func TestCheck(t *testing.T) {
 	type testCase struct {
 		description   string
-		pods          []podIdent
+		pods          []NamespacedName
 		fingerprint   string
 		expectedError error
 	}

--- a/tracing.go
+++ b/tracing.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podfingerprint
+
+// NamespacedName is a Namespace/Name pair
+type NamespacedName struct {
+	Namespace string
+	Name      string
+}
+
+func (nn NamespacedName) GetNamespace() string {
+	return nn.Namespace
+}
+
+func (nn NamespacedName) GetName() string {
+	return nn.Name
+}
+
+func (nn NamespacedName) String() string {
+	return nn.Namespace + "/" + nn.Name
+}
+
+// Tracer tracks the actions needed to compute a fingerprint
+type Tracer interface {
+	// Start is called when the Fingerprint is initialized
+	Start(numPods int)
+	// Add is called when a new pod data is fed to the fingerprint,
+	// respecting the invocation order (no reordering done)
+	Add(namespace, name string)
+	// Sign is called when the fingerprint is asked for the signature
+	Sign(computed string)
+	// Check is called when the fingerprint is asked to check
+	Check(expected string)
+}
+
+// NullTracer implements the Tracer interface and does nothing
+type NullTracer struct{}
+
+func (nt NullTracer) Start(numPods int)          {}
+func (nt NullTracer) Add(namespace, name string) {}
+func (nt NullTracer) Sign(computed string)       {}
+func (nt NullTracer) Check(expected string)      {}
+
+// Status represents the working status of a Fingerprint
+type Status struct {
+	FingerprintExpected string           `json:"fingerprintExpected,omitempty"`
+	FingerprintComputed string           `json:"fingerprintComputed,omitempty"`
+	Pods                []NamespacedName `json:"pods,omitempty"`
+}
+
+func (st *Status) Start(numPods int) {
+	st.Pods = make([]NamespacedName, 0, numPods)
+}
+
+func (st *Status) Add(namespace, name string) {
+	st.Pods = append(st.Pods, NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	})
+}
+
+func (st *Status) Sign(computed string) {
+	st.FingerprintComputed = computed
+}
+
+func (st *Status) Check(expected string) {
+	st.FingerprintExpected = expected
+}
+
+type TracingFingerprint struct {
+	Fingerprint
+	tracer Tracer
+}
+
+// NewTracingFingerprint creates a empty Fingerprint.
+// The size parameter is a hint for the expected size of the pod set. Use 0 if you don't know.
+// Values of size < 0 are ignored.
+// The tracer parameter attach a tracer to this fingerprint. Client code can peek inside the
+// fingerprint parameters, for debug purposes.
+func NewTracingFingerprint(size int, tracer Tracer) *TracingFingerprint {
+	tf := &TracingFingerprint{}
+	tf.Fingerprint.Reset(size)
+	tf.tracer = tracer
+	return tf
+}
+
+// AddPod adds a pod to the pod set.
+func (tf *TracingFingerprint) AddPod(pod PodIdentifier) error {
+	tf.tracer.Add(pod.GetNamespace(), pod.GetName())
+	return tf.Fingerprint.AddPod(pod)
+}
+
+// AddPod add a pod by its namespace/name pair to the pod set.
+func (tf *TracingFingerprint) Add(namespace, name string) error {
+	tf.tracer.Add(namespace, name)
+	return tf.Fingerprint.Add(namespace, name)
+}
+
+// Sum computes the fingerprint of the *current* pod set as slice of bytes.
+// It is legal to keep adding pods after calling Sum, but the fingerprint of
+// the set will change. The output of Sum is guaranteed to be stable if the
+// content of the pod set is stable.
+func (tf *TracingFingerprint) Sum() []byte {
+	return tf.Fingerprint.Sum()
+}
+
+// Sign computes the pod set fingerprint as string.
+// The string should be considered a opaque identifier and checked only for
+// equality, or fed into Check
+func (tf *TracingFingerprint) Sign() string {
+	sign := tf.Fingerprint.Sign()
+	tf.tracer.Sign(sign)
+	return sign
+}
+
+// Check verifies if the provided fingerprint matches the current pod set.
+// Returns nil if the verification holds, error otherwise, or if the fingerprint
+// string is malformed.
+func (tf *TracingFingerprint) Check(sign string) error {
+	tf.tracer.Check(sign)
+	return tf.Fingerprint.Check(sign)
+}

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package podfingerprint
+
+import (
+	"encoding/json"
+	"math/rand"
+	"testing"
+)
+
+func TestNamespacedNameString(t *testing.T) {
+	nn := NamespacedName{
+		Namespace: "foo",
+		Name:      "bar",
+	}
+
+	expected := "foo/bar"
+	got := nn.String()
+	if got != expected {
+		t.Errorf("string failed: got %q expected %q", got, expected)
+	}
+}
+
+func TestNamespacedNameGetters(t *testing.T) {
+	nn := NamespacedName{
+		Namespace: "foo",
+		Name:      "bar",
+	}
+
+	nsGot := nn.GetNamespace()
+	nGot := nn.GetName()
+	if nsGot != "foo" || nGot != "bar" {
+		t.Errorf("getters failed: %q vs %q and %q vs %q", nsGot, "foo", nGot, "bar")
+	}
+}
+
+var expectedStatusJson string = `{"fingerprintExpected":"pfp0v001b92008c14168b3a6","fingerprintComputed":"pfp0v001b92008c14168b3a6","pods":[{"Namespace":"ns1","Name":"n1"},{"Namespace":"ns1","Name":"n2"},{"Namespace":"ns2","Name":"n1"},{"Namespace":"ns3","Name":"n1"},{"Namespace":"ns3","Name":"n2"}]}`
+
+func TestTraceStatus(t *testing.T) {
+	pods := []NamespacedName{
+		{
+			Namespace: "ns1",
+			Name:      "n1",
+		},
+		{
+			Namespace: "ns1",
+			Name:      "n2",
+		},
+		{
+			Namespace: "ns2",
+			Name:      "n1",
+		},
+		{
+			Namespace: "ns3",
+			Name:      "n1",
+		},
+		{
+			Namespace: "ns3",
+			Name:      "n2",
+		},
+	}
+
+	st := Status{}
+	fp := NewTracingFingerprint(len(pods), &st)
+	for _, pod := range pods {
+		fp.Add(pod.Namespace, pod.Name)
+	}
+	fp.Sign()
+	err := fp.Check("pfp0v001b92008c14168b3a6")
+	if err != nil {
+		t.Fatalf("fp check error: %v", err)
+	}
+
+	data, err := json.Marshal(st)
+	if err != nil {
+		t.Fatalf("JSON marshal error: %v", err)
+	}
+	got := string(data)
+	if got != expectedStatusJson {
+		t.Errorf("status report error.\ngot: %s\nexp: %s", got, expectedStatusJson)
+	}
+}
+
+func TestSignCrosscheck(t *testing.T) {
+	if len(pods) == 0 || podsErr != nil {
+		t.Fatalf("cannot load the test data: %v", podsErr)
+	}
+
+	localPods := make([]NamespacedName, len(pods))
+	copy(localPods, pods)
+	rand.Shuffle(len(localPods), func(i, j int) {
+		localPods[i], localPods[j] = localPods[j], localPods[i]
+	})
+
+	fp := NewFingerprint(0)
+	for _, pod := range pods {
+		fp.Add(pod.Namespace, pod.Name)
+	}
+	fp2 := NewTracingFingerprint(0, NullTracer{})
+	for _, localPod := range localPods {
+		fp2.Add(localPod.Namespace, localPod.Name)
+	}
+
+	x := fp.Sign()
+	x2 := fp2.Sign()
+	if x != x2 {
+		t.Fatalf("signature not stable: %q vs %q", x, x2)
+	}
+}


### PR DESCRIPTION
Debugging the fingerprint computation requies to inspect which pods weere considered. The ordering is guaranteed by the fingerprint implementation, but it's still important to make sure the right set was considered.

To support this sporadic but critical troubleshooting need, we add minimal common infrastructure all the clients can consume:
- a minimal (and which we want to keep minimal) tracing support
- a common representation of the debugging data

Signed-off-by: Francesco Romani <fromani@redhat.com>