### PR TITLE
tracing: status: add canonical repr

### DIFF
--- a/tracing.go
+++ b/tracing.go
@@ -16,6 +16,11 @@
 
 package podfingerprint
 
+import (
+	"fmt"
+	"strings"
+)
+
 // NamespacedName is a Namespace/Name pair
 type NamespacedName struct {
 	Namespace string
@@ -79,6 +84,23 @@ func (st *Status) Sign(computed string) {
 
 func (st *Status) Check(expected string) {
 	st.FingerprintExpected = expected
+}
+
+// Repr represents the Status as compact yet human-friendly string
+func (st Status) Repr() string {
+	var sb strings.Builder
+
+	sb.WriteString(fmt.Sprintf("> processing %d pods\n", len(st.Pods)))
+	for _, pod := range st.Pods {
+		sb.WriteString("+ " + pod.Namespace + "/" + pod.Name + "\n")
+	}
+
+	sb.WriteString("= " + st.FingerprintComputed + "\n")
+	if st.FingerprintExpected != "" {
+		sb.WriteString("V " + st.FingerprintExpected + "\n")
+	}
+
+	return sb.String()
 }
 
 type TracingFingerprint struct {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -50,7 +50,7 @@ func TestNamespacedNameGetters(t *testing.T) {
 
 var expectedStatusJson string = `{"fingerprintExpected":"pfp0v001b92008c14168b3a6","fingerprintComputed":"pfp0v001b92008c14168b3a6","pods":[{"Namespace":"ns1","Name":"n1"},{"Namespace":"ns1","Name":"n2"},{"Namespace":"ns2","Name":"n1"},{"Namespace":"ns3","Name":"n1"},{"Namespace":"ns3","Name":"n2"}]}`
 
-func TestTraceStatus(t *testing.T) {
+func TestTraceStatusJSON(t *testing.T) {
 	pods := []NamespacedName{
 		{
 			Namespace: "ns1",
@@ -92,6 +92,57 @@ func TestTraceStatus(t *testing.T) {
 	got := string(data)
 	if got != expectedStatusJson {
 		t.Errorf("status report error.\ngot: %s\nexp: %s", got, expectedStatusJson)
+	}
+}
+
+var expectedStatusRepr = `> processing 5 pods
++ ns1/n1
++ ns1/n2
++ ns2/n1
++ ns3/n1
++ ns3/n2
+= pfp0v001b92008c14168b3a6
+V pfp0v001b92008c14168b3a6
+`
+
+func TestTraceStatusRepr(t *testing.T) {
+	pods := []NamespacedName{
+		{
+			Namespace: "ns1",
+			Name:      "n1",
+		},
+		{
+			Namespace: "ns1",
+			Name:      "n2",
+		},
+		{
+			Namespace: "ns2",
+			Name:      "n1",
+		},
+		{
+			Namespace: "ns3",
+			Name:      "n1",
+		},
+		{
+			Namespace: "ns3",
+			Name:      "n2",
+		},
+	}
+
+	st := Status{}
+	fp := NewTracingFingerprint(len(pods), &st)
+	for _, pod := range pods {
+		fp.Add(pod.Namespace, pod.Name)
+	}
+	fp.Sign()
+	err := fp.Check("pfp0v001b92008c14168b3a6")
+	if err != nil {
+		t.Fatalf("fp check error: %v", err)
+	}
+
+	got := st.Repr()
+	if got != expectedStatusRepr {
+		t.Errorf("status repr error.\ngot: %s\nexp: %s", got, expectedStatusRepr)
 	}
 }
 


### PR DESCRIPTION
Alongside the JSON annotations, add a canonical,
concise yet human friendly string representation
of the `podfingerprint.Status`.

Signed-off-by: Francesco Romani <fromani@redhat.com>