### PR TITLE
nrt: add attribute name definition

### DIFF
--- a/podfingerprint.go
+++ b/podfingerprint.go
@@ -48,6 +48,9 @@ const (
 	// Annotation is the recommended key to use to annotate objects
 	// with the fingerprint.
 	Annotation = "topology.node.k8s.io/fingerprint"
+	// Attribute is the recommended attribute name to use in
+	// NodeResourceTopology objects
+	Attribute = "nodeTopologyPodsFingerprint"
 )
 
 const (


### PR DESCRIPTION
Since the NRT API is moving towards top-level attributes (see:
https://github.com/k8stopologyawareschedwg/noderesourcetopology-api/issues/24) add the preferred Attribute Name alongside the existing Annotatio Name.

Signed-off-by: Francesco Romani <fromani@redhat.com>