### PR TITLE
pfp: add constants to declare the compute method

### DIFF
--- a/podfingerprint.go
+++ b/podfingerprint.go
@@ -51,6 +51,15 @@ const (
 	// Attribute is the recommended attribute name to use in
 	// NodeResourceTopology objects
 	Attribute = "nodeTopologyPodsFingerprint"
+	// AttributeMethod is the recommended attribute name to use
+	// in NodeResourceTopology objects to declare how the
+	// fingerprint was being computed
+	AttributeMethod = "nodeTopologyPodsFingerprintMethod"
+)
+
+const (
+	MethodAll                    = "all"                      // unrestricted. Just compute all the pods
+	MethodWithExclusiveResources = "with-exclusive-resources" // only consider pods which require exclusive resources
 )
 
 const (


### PR DESCRIPTION
PFP can be computed in different ways, filtering pods which should or should not be included in the signature. Two clear methods emerged yet:
- unrestricted/all: just include all pods known into the signature. This is probably the sane default for everyone.
- with-exclusive-resources: only include in the signature pods which have exclusive resources, because these are the pods which require NUMA/zone locality, everything else doesn't contribute to the NUMA accounting.

In this PR we add constants to express these two methods, this way the entities which communicate through NRT objects have a clear way to know how a PFP is computed.