### PR TITLE
feat: introduce the record package

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: GO vetting
       run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/k8stopologyawareschedwg/podfingerprint
 
-go 1.17
+go 1.18
 
 require github.com/OneOfOne/xxhash v1.2.8

--- a/notify_test.go
+++ b/notify_test.go
@@ -90,3 +90,144 @@ func TestMarkCompleted(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkCompletedWithoutSet(t *testing.T) {
+	type testCase struct {
+		name          string
+		sink          chan Status
+		status        Status
+		expectedError error
+	}
+
+	testCases := []testCase{
+		{
+			name: "no completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: nil, // explicit
+		},
+		{
+			name: "with completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: make(chan Status, 5), // anything > 1 is fine
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := MarkCompleted(tc.status)
+			if err != tc.expectedError {
+				t.Errorf("got error=%v expected=%v", err, tc.expectedError)
+			}
+			if tc.sink != nil && len(tc.sink) != 0 {
+				t.Errorf("unexpected data in sink: %d", len(tc.sink))
+			}
+		})
+	}
+}
+
+func TestMarkCompletedWithExplicitClean(t *testing.T) {
+	type testCase struct {
+		name          string
+		sink          chan Status
+		status        Status
+		expectedError error
+	}
+
+	testCases := []testCase{
+		{
+			name: "no completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: nil, // explicit
+		},
+		{
+			name: "with completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: make(chan Status, 5), // anything > 1 is fine
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			CleanCompletionSink()
+			err := MarkCompleted(tc.status)
+			if err != tc.expectedError {
+				t.Errorf("got error=%v expected=%v", err, tc.expectedError)
+			}
+			if tc.sink != nil && len(tc.sink) != 0 {
+				t.Errorf("unexpected data in sink: %d", len(tc.sink))
+			}
+		})
+	}
+}

--- a/record/codec.go
+++ b/record/codec.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package record
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func NodeNameToFileName(name string) string {
+	return strings.ReplaceAll(name, ".", "_")
+}
+
+func FileNameToNodeName(name string) string {
+	return strings.ReplaceAll(name, "_", ".")
+}
+
+// DumpToFile encodes in JSON and dumps the given `obj` to a file.
+// `dir` is the base directory on which the file must be created
+// `file` is the name of the file to create in `dir`.
+// The old file, if present, is always updated atomically.
+func DumpToFile(dir, file string, obj any) error {
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	dst, err := os.CreateTemp(dir, "__"+file)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(dst.Name()) // either way, we need to get rid of this
+
+	_, err = dst.Write(data)
+	if err != nil {
+		return err
+	}
+
+	err = dst.Close()
+	if err != nil {
+		return err
+	}
+
+	return os.Rename(dst.Name(), filepath.Join(dir, file))
+}
+
+// LoadFromFile decodes the JSON data found in `file` placed in `dir`
+// and stores it into `obj`, which must be a pointer.
+func LoadFromFile(dir, file string, obj any) error {
+	data, err := os.ReadFile(filepath.Join(dir, file))
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(data, obj)
+}

--- a/record/recorder.go
+++ b/record/recorder.go
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package record
+
+import (
+	"errors"
+	"time"
+
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+)
+
+var (
+	ErrInvalidCapacity  = errors.New("invalid capacity")
+	ErrInvalidNodeCount = errors.New("invalid node count")
+	ErrMissingNode      = errors.New("missing node")
+	ErrMismatchingNode  = errors.New("mismatching node")
+	ErrTooManyNodes     = errors.New("excessive node count")
+)
+
+// RecordedStatus is a Status plus additional metadata
+type RecordedStatus struct {
+	podfingerprint.Status
+	// RecordTime is a timestamp of when the RecordedStatus was added to the record
+	RecordTime time.Time `json:"recordTime"`
+}
+
+func (rs RecordedStatus) Equal(x RecordedStatus) bool {
+	return rs.Status.Equal(x.Status)
+}
+
+// Timestampr is the function called to get the timestamps. A good default is time.Now
+type Timestamper func() time.Time
+
+// NodeRecorder stores all the recorded statuses for a given node name.
+// Statuses belonging to different nodes won't be accepted.
+type NodeRecorder struct {
+	timestamper func() time.Time
+	nodeName    string // shortcut
+	capacity    int
+	statuses    []RecordedStatus
+}
+
+// NewNodeRecorder creates a new recorder for the given node with the given capacity.
+// The record is a ring buffer, so only the latest <capacity> Statuses are kept at any time.
+// The timestamper callback is used to mark times. Use `time.Now` if unsure.
+// Returns the newly created instance; if parameters are incorrect, returns an error, on which
+// case the returned instance should be ignored.
+func NewNodeRecorder(nodeName string, capacity int, timestamper Timestamper) (*NodeRecorder, error) {
+	if nodeName == "" {
+		return nil, ErrMissingNode
+	}
+	if capacity < 1 {
+		return nil, ErrInvalidCapacity
+	}
+	nr := NodeRecorder{
+		timestamper: timestamper,
+		nodeName:    nodeName,
+		capacity:    capacity,
+	}
+	if capacity == 1 { // handle common special case
+		nr.statuses = make([]RecordedStatus, 1)
+	}
+	return &nr, nil
+}
+
+// Push adds a new Status to the record, evicting the oldest Status if necessary.
+// The pushed status is a full independent copy of the provided Status.
+// If the Status added is inconsistent, returns an error detailing the reason.
+// Statuses are evicted only in case of success.
+func (nr *NodeRecorder) Push(st podfingerprint.Status) error {
+	if st.NodeName == "" {
+		return ErrMissingNode
+	}
+	if st.NodeName != nr.nodeName {
+		return ErrMismatchingNode
+	}
+	if nr.capacity == 1 { // handle common special case, avoid any resize
+		nr.statuses[0] = RecordedStatus{
+			Status:     st.Clone(),
+			RecordTime: nr.timestamper(),
+		}
+		return nil
+	}
+	if nr.Len() == nr.Cap() {
+		// drop the older sample
+		nr.statuses = nr.statuses[1:]
+	}
+	nr.statuses = append(nr.statuses, RecordedStatus{
+		Status:     st.Clone(),
+		RecordTime: nr.timestamper(),
+	})
+	return nil
+}
+
+// Len returns how many Statuses are currently held in the NodeRecorder
+func (nr *NodeRecorder) Len() int {
+	return len(nr.statuses)
+}
+
+// Cap returns the maximum capacity of the NodeRecorder
+func (nr *NodeRecorder) Cap() int {
+	return nr.capacity
+}
+
+// Content() returns a shallow copy of all the recorded statuses.
+func (nr *NodeRecorder) Content() []RecordedStatus {
+	return nr.statuses
+}
+
+// Recorder stores all the recorded statuses, dividing them by node name.
+// There is a hard cap of how many nodes are managed, and how many Statuses are recorded per node.
+type Recorder struct {
+	nodes        map[string]*NodeRecorder
+	nodeCapacity int
+	maxNodes     int
+	timestamper  Timestamper
+}
+
+// NewRecorder creates a new recorder up to the given node count, each with the given capacity.
+// Each per-node recorder is a ring buffer, so only the latest <nodeCapacity> Statuses are kept
+// at any time for each node. The per-node records are created lazily as needed.
+// The timestamper callback is used to mark times. Use `time.Now` if unsure.
+// Returns the newly created instance; if parameters are incorrect, returns an error, on which
+// case the returned instance should be ignored.
+func NewRecorder(maxNodes, nodeCapacity int, timestamper Timestamper) (*Recorder, error) {
+	if maxNodes < 1 {
+		return nil, ErrInvalidNodeCount
+	}
+	if nodeCapacity < 1 {
+		return nil, ErrInvalidCapacity
+	}
+	return &Recorder{
+		nodes:        make(map[string]*NodeRecorder),
+		nodeCapacity: nodeCapacity,
+		maxNodes:     maxNodes,
+		timestamper:  timestamper,
+	}, nil
+}
+
+// Cap returns the maximum nodes allowed in this Recorder
+func (rr *Recorder) MaxNodes() int {
+	return rr.maxNodes
+}
+
+// Cap returns the maximum capacity of each NodeRecorder
+func (rr *Recorder) Cap() int {
+	return rr.nodeCapacity
+}
+
+// CountNodes returns how many Nodes are known to the Recorder
+func (rr *Recorder) CountNodes() int {
+	return len(rr.nodes)
+}
+
+// CountRecords returns how many Records are held for the give nodeName in the Recorder
+func (rr *Recorder) CountRecords(nodeName string) int {
+	nr, ok := rr.nodes[nodeName]
+	if !ok {
+		return 0
+	}
+	return nr.Len()
+}
+
+// Len returns the total number of records across all nodes
+func (rr *Recorder) Len() int {
+	tot := 0
+	for _, nr := range rr.nodes {
+		tot += nr.Len()
+	}
+	return tot
+}
+
+// Push adds a new Status to the record for its node, evicting the oldest Status
+// belonging to the same node if necessary.
+// Per-node records are created lazily as needed, up to the configured maximum.
+// The pushed status is a full independent copy of the provided Status.
+// If the Status added is inconsistent, returns an error detailing the reason.
+// Statuses are evicted only in case of success.
+func (rr *Recorder) Push(st podfingerprint.Status) error {
+	if st.NodeName == "" {
+		return ErrMissingNode
+	}
+	if len(rr.nodes) >= rr.maxNodes {
+		return ErrTooManyNodes
+	}
+	var err error
+	nr, ok := rr.nodes[st.NodeName]
+	if !ok {
+		nr, err = NewNodeRecorder(st.NodeName, rr.nodeCapacity, rr.timestamper)
+		if err != nil {
+			return err
+		}
+		rr.nodes[st.NodeName] = nr
+	}
+	return nr.Push(st)
+}
+
+// Content() returns a shallow copy of all the recorded statuses, by node name.
+func (rr *Recorder) Content() map[string][]RecordedStatus {
+	ret := make(map[string][]RecordedStatus, len(rr.nodes))
+	for nodeName, nr := range rr.nodes {
+		ret[nodeName] = nr.Content()
+	}
+	return ret
+}
+
+// ContentForNode returns a shallow copy of all the recorded status for the given nodeName.
+// Returns the content and a boolean which tells if the node is known or not
+func (rr *Recorder) ContentForNode(nodeName string) ([]RecordedStatus, bool) {
+	nr, ok := rr.nodes[nodeName]
+	if !ok {
+		return []RecordedStatus{}, false
+	}
+	return nr.Content(), true
+}

--- a/record/recorder_test.go
+++ b/record/recorder_test.go
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2025 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package record
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/k8stopologyawareschedwg/podfingerprint"
+)
+
+func TestNodeRecorderCreate(t *testing.T) {
+	nr, err := NewNodeRecorder("test-node", 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nr.Len() != 0 {
+		t.Errorf("non-empty recorder after creation")
+	}
+	x := nr.Cap()
+	if x != 16 {
+		t.Errorf("mismatching cap after creation: %v", x)
+	}
+}
+
+func TestNodeRecorderCreateInvalid(t *testing.T) {
+	_, err := NewNodeRecorder("test-node", 0, time.Now)
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+	if !errors.Is(err, ErrInvalidCapacity) {
+		t.Errorf("unexpected error: %v %T", err, err)
+	}
+}
+
+func TestNodeRecorderPushMissingNodeName(t *testing.T) {
+	nr, err := NewNodeRecorder("test-node", 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = nr.Push(podfingerprint.Status{
+		NodeName: "",
+	})
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+	if !errors.Is(err, ErrMissingNode) {
+		t.Fatalf("push: unexpected error: %v", err)
+	}
+}
+
+func TestNodeRecorderPushMismatchingNodeName(t *testing.T) {
+	nr, err := NewNodeRecorder("test-node", 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = nr.Push(podfingerprint.Status{
+		NodeName: "FOOBAR",
+	})
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+	if !errors.Is(err, ErrMismatchingNode) {
+		t.Fatalf("push: unexpected error: %v", err)
+	}
+}
+
+func TestNodeRecorderPushBasic(t *testing.T) {
+	nr, err := NewNodeRecorder("test-node", 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = nr.Push(podfingerprint.Status{
+		NodeName: "test-node",
+	})
+	if err != nil {
+		t.Fatalf("push: unexpected error: %v", err)
+	}
+	if nr.Len() != 1 {
+		t.Errorf("empty recorder after push")
+	}
+}
+
+func TestNodeRecorderSingleEntryPushEvict(t *testing.T) {
+	nr, err := NewNodeRecorder("test-node", 1, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	num := 7 // random low enough number > 1
+	for idx := 0; idx < num; idx++ {
+		if err := nr.Push(podfingerprint.Status{
+			NodeName:            "test-node",
+			FingerprintExpected: fmt.Sprintf("pfp0v%d", idx),
+		}); err != nil {
+			t.Fatalf("push: unexpected error: %v", err)
+		}
+		sz := nr.Len()
+		if sz != 1 {
+			t.Fatalf("unexpected status count: %d", sz)
+		}
+	}
+	sts := nr.Content()
+	if len(sts) != 1 {
+		t.Fatalf("unexpected content: %v", sts)
+	}
+	got := sts[0]
+	exp := RecordedStatus{
+		Status: podfingerprint.Status{
+			NodeName:            "test-node",
+			FingerprintExpected: "pfp0v6",
+		},
+	}
+	if !exp.Equal(got) {
+		t.Fatalf("unexpected content: got %#v exp %#v", got, exp)
+	}
+}
+
+func TestNodeRecorderMultiEntryPushContentEvict(t *testing.T) {
+	nr, err := NewNodeRecorder("test-node", 3, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	num := 7 // random low enough number > 1
+	for idx := 0; idx < num; idx++ {
+		if err := nr.Push(podfingerprint.Status{
+			NodeName:            "test-node",
+			FingerprintExpected: fmt.Sprintf("pfp0v%d", idx),
+		}); err != nil {
+			t.Fatalf("push: unexpected error: %v", err)
+		}
+		sz := nr.Len()
+		if sz > 3 {
+			t.Fatalf("unexpected status count: %d", sz)
+		}
+	}
+	sts := nr.Content()
+	if len(sts) != 3 {
+		t.Fatalf("unexpected content: %v", sts)
+	}
+	for idx := 0; idx < 3; idx++ {
+		got := sts[len(sts)-1-idx]
+		exp := RecordedStatus{
+			Status: podfingerprint.Status{
+				NodeName:            "test-node",
+				FingerprintExpected: fmt.Sprintf("pfp0v%d", num-1-idx),
+			},
+		}
+		if !exp.Equal(got) {
+			t.Fatalf("unexpected content: got %#v exp %#v", got, exp)
+		}
+	}
+}
+
+func TestRecorderCreate(t *testing.T) {
+	rr, err := NewRecorder(8, 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	x := rr.Cap()
+	if x != 16 {
+		t.Errorf("mismatching cap after creation: %v", x)
+	}
+	n := rr.MaxNodes()
+	if n != 8 {
+		t.Errorf("mismatching maxNodes after creation: %v", n)
+	}
+	if rr.CountNodes() != 0 {
+		t.Errorf("non-zero node count after creation")
+	}
+	if rr.Len() != 0 {
+		t.Errorf("non-empty recorder after creation")
+	}
+}
+
+func TestRecorderCreateInvalid(t *testing.T) {
+	_, err := NewRecorder(8, 0, time.Now)
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+	if !errors.Is(err, ErrInvalidCapacity) {
+		t.Errorf("unexpected error: %v %T", err, err)
+	}
+
+	_, err = NewRecorder(0, 32, time.Now)
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+	if !errors.Is(err, ErrInvalidNodeCount) {
+		t.Errorf("unexpected error: %v %T", err, err)
+	}
+
+}
+
+func TestRecorderPushMissingNodeName(t *testing.T) {
+	rr, err := NewRecorder(8, 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = rr.Push(podfingerprint.Status{
+		NodeName: "",
+	})
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+	if !errors.Is(err, ErrMissingNode) {
+		t.Fatalf("push: unexpected error: %v", err)
+	}
+}
+
+func TestRecorderPushTooManyNodes(t *testing.T) {
+	rr, err := NewRecorder(1, 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := rr.Push(podfingerprint.Status{
+		NodeName: "node-0",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rr.CountNodes() != 1 {
+		t.Fatalf("unexpected node count")
+	}
+	err = rr.Push(podfingerprint.Status{
+		NodeName: "node-1",
+	})
+	if err == nil {
+		t.Fatalf("unexpected success")
+	}
+	if rr.CountNodes() != 1 {
+		t.Fatalf("unexpected node count")
+	}
+	if rr.Len() != 1 {
+		t.Fatalf("unexpected status count")
+	}
+	if rr.CountRecords("node-0") != 1 {
+		t.Fatalf("unexpected status count for %q", "node-0")
+	}
+	if rr.CountRecords("node-1") != 0 {
+		t.Fatalf("unexpected status count for %q", "node-1")
+	}
+	if !errors.Is(err, ErrTooManyNodes) {
+		t.Fatalf("push: unexpected error: %v", err)
+	}
+}
+
+func TestRecorderPushMultipleNodes(t *testing.T) {
+	rr, err := NewRecorder(8, 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// gaps and dupes are intentional
+	testNodes := []string{"node-0", "node-1", "node-3", "node-0"}
+	for _, nodeName := range testNodes {
+		if err := rr.Push(podfingerprint.Status{
+			NodeName: nodeName,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if rr.Len() != len(testNodes) {
+		t.Fatalf("unexpected status count")
+	}
+	if rr.CountNodes() != 3 {
+		t.Fatalf("unexpected node count")
+	}
+	if rr.CountRecords("node-0") != 2 {
+		t.Fatalf("unexpected status count for %q", "node-0")
+	}
+}
+
+func TestRecorderPushMultipleNodesContent(t *testing.T) {
+	rr, err := NewRecorder(8, 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// gaps and dupes are intentional
+	testNodes := []string{"node-0", "node-1", "node-3", "node-0"}
+	for _, nodeName := range testNodes {
+		if err := rr.Push(podfingerprint.Status{
+			NodeName: nodeName,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	sts := rr.Content()
+	if len(sts) != 3 {
+		t.Fatalf("unexpected node count")
+	}
+	if len(sts["node-0"]) != 2 {
+		t.Fatalf("unexpected status count for %q", "node-0")
+	}
+	if len(sts["node-3"]) != 1 {
+		t.Fatalf("unexpected status count for %q", "node-3")
+	}
+	exp := RecordedStatus{
+		Status: podfingerprint.Status{
+			NodeName: "node-3",
+		},
+	}
+	if !exp.Equal(sts["node-3"][0]) {
+		t.Fatalf("unexpected status for %q", "node-3")
+	}
+
+	got, ok := rr.ContentForNode("node-1")
+	if !ok || len(got) != 1 {
+		t.Fatalf("unexpected status for %q", "node-1")
+	}
+	exp = RecordedStatus{
+		Status: podfingerprint.Status{
+			NodeName: "node-1",
+		},
+	}
+	if !exp.Equal(got[0]) {
+		t.Fatalf("unexpected status for %q", "node-1")
+	}
+}
+
+func TestRecorderPushMultipleNodesContentUnknownForNode(t *testing.T) {
+	rr, err := NewRecorder(8, 16, time.Now)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// gaps and dupes are intentional
+	testNodes := []string{"node-0", "node-1", "node-3", "node-0"}
+	for _, nodeName := range testNodes {
+		if err := rr.Push(podfingerprint.Status{
+			NodeName: nodeName,
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	got, ok := rr.ContentForNode("node-99") // note node intentionally unknown
+	if ok || len(got) != 0 {
+		t.Fatalf("unexpected status count for %q", "node-99")
+	}
+}

--- a/tracing.go
+++ b/tracing.go
@@ -18,6 +18,7 @@ package podfingerprint
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -66,6 +67,25 @@ type Status struct {
 	FingerprintComputed string           `json:"fingerprintComputed,omitempty"`
 	Pods                []NamespacedName `json:"pods,omitempty"`
 	NodeName            string           `json:"nodeName,omitempty"`
+}
+
+func (s Status) Equal(x Status) bool {
+	if s.NodeName != x.NodeName {
+		return false
+	}
+	if s.FingerprintExpected != x.FingerprintExpected {
+		return false
+	}
+	if s.FingerprintComputed != x.FingerprintComputed {
+		return false
+	}
+	if len(s.Pods) != len(x.Pods) {
+		return false
+	}
+	if len(s.Pods) > 0 && !reflect.DeepEqual(s.Pods, x.Pods) {
+		return false
+	}
+	return true
 }
 
 func MakeStatus(nodeName string) Status {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -219,3 +219,154 @@ func TestStatusClone(t *testing.T) {
 		t.Errorf("original modified changing the clone!\norig=%s\norig2=%s", string(origData), string(origData2))
 	}
 }
+
+func TestStatusEqual(t *testing.T) {
+	X := Status{
+		FingerprintExpected: "PFPExpectedOrig",
+		FingerprintComputed: "PFPComputedOrig",
+		Pods: []NamespacedName{
+			{
+				Namespace: "NSOrig1",
+				Name:      "Name1",
+			},
+			{
+				Namespace: "NSOrig2",
+				Name:      "Name2",
+			},
+		},
+		NodeName: "Node",
+	}
+	testCases := []struct {
+		Desc     string
+		Y        Status
+		Expected bool
+	}{
+		{
+			Desc: "clone",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedOrig",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: true,
+		},
+		{
+			Desc: "diff: nodeName",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedOrig",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "NodeFooBar",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pfp Expected",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedDIFF",
+				FingerprintComputed: "PFPComputedOrig",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pfp Computed",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pod count",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pod values",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig5",
+						Name:      "Name5",
+					},
+					{
+						Namespace: "NSOrigX",
+						Name:      "NameX",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pod missing",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				NodeName:            "Node",
+			},
+			Expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			got := X.Equal(tc.Y)
+			if got != tc.Expected {
+				t.Fatalf("got=%v expected=%v", got, tc.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `record` package implements types and functions to store Statuses in ringbuffers, per-node or per-process (so possibly multiple nodes at once).

This is an additional optional package. Applications using the fingerprint often needs to store statuses to enable troubleshooting, so the `record` packages make it easier to centralize this code.

There are no impacts on the rest of the codebase,
besides minor additions, again optional, to better support the `record` flows, and some extra tests
added along the way.

Long story short, this new code is self-contained, opt-in and as independent as possible.