### PR TITLE
maint: improve coverage, add and test status.Equal

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up golang
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.18
 
     - name: GO vetting
       run: go vet ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/k8stopologyawareschedwg/podfingerprint
 
-go 1.17
+go 1.18
 
 require github.com/OneOfOne/xxhash v1.2.8

--- a/notify_test.go
+++ b/notify_test.go
@@ -90,3 +90,144 @@ func TestMarkCompleted(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkCompletedWithoutSet(t *testing.T) {
+	type testCase struct {
+		name          string
+		sink          chan Status
+		status        Status
+		expectedError error
+	}
+
+	testCases := []testCase{
+		{
+			name: "no completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: nil, // explicit
+		},
+		{
+			name: "with completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: make(chan Status, 5), // anything > 1 is fine
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := MarkCompleted(tc.status)
+			if err != tc.expectedError {
+				t.Errorf("got error=%v expected=%v", err, tc.expectedError)
+			}
+			if tc.sink != nil && len(tc.sink) != 0 {
+				t.Errorf("unexpected data in sink: %d", len(tc.sink))
+			}
+		})
+	}
+}
+
+func TestMarkCompletedWithExplicitClean(t *testing.T) {
+	type testCase struct {
+		name          string
+		sink          chan Status
+		status        Status
+		expectedError error
+	}
+
+	testCases := []testCase{
+		{
+			name: "no completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: nil, // explicit
+		},
+		{
+			name: "with completion sink",
+			status: Status{
+				NodeName: "test-node-0",
+				Pods: []NamespacedName{
+					{
+						Namespace: "ns-1",
+						Name:      "pod-1",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-2",
+					},
+					{
+						Namespace: "ns-2",
+						Name:      "pod-3",
+					},
+				},
+				FingerprintExpected: "pfp0v001807d932586d44a8a",
+				FingerprintComputed: "pfp0v001807d932586d44a8a",
+			},
+			sink: make(chan Status, 5), // anything > 1 is fine
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			CleanCompletionSink()
+			err := MarkCompleted(tc.status)
+			if err != tc.expectedError {
+				t.Errorf("got error=%v expected=%v", err, tc.expectedError)
+			}
+			if tc.sink != nil && len(tc.sink) != 0 {
+				t.Errorf("unexpected data in sink: %d", len(tc.sink))
+			}
+		})
+	}
+}

--- a/tracing.go
+++ b/tracing.go
@@ -18,6 +18,7 @@ package podfingerprint
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -66,6 +67,25 @@ type Status struct {
 	FingerprintComputed string           `json:"fingerprintComputed,omitempty"`
 	Pods                []NamespacedName `json:"pods,omitempty"`
 	NodeName            string           `json:"nodeName,omitempty"`
+}
+
+func (s Status) Equal(x Status) bool {
+	if s.NodeName != x.NodeName {
+		return false
+	}
+	if s.FingerprintExpected != x.FingerprintExpected {
+		return false
+	}
+	if s.FingerprintComputed != x.FingerprintComputed {
+		return false
+	}
+	if len(s.Pods) != len(x.Pods) {
+		return false
+	}
+	if len(s.Pods) > 0 && !reflect.DeepEqual(s.Pods, x.Pods) {
+		return false
+	}
+	return true
 }
 
 func MakeStatus(nodeName string) Status {

--- a/tracing_test.go
+++ b/tracing_test.go
@@ -219,3 +219,154 @@ func TestStatusClone(t *testing.T) {
 		t.Errorf("original modified changing the clone!\norig=%s\norig2=%s", string(origData), string(origData2))
 	}
 }
+
+func TestStatusEqual(t *testing.T) {
+	X := Status{
+		FingerprintExpected: "PFPExpectedOrig",
+		FingerprintComputed: "PFPComputedOrig",
+		Pods: []NamespacedName{
+			{
+				Namespace: "NSOrig1",
+				Name:      "Name1",
+			},
+			{
+				Namespace: "NSOrig2",
+				Name:      "Name2",
+			},
+		},
+		NodeName: "Node",
+	}
+	testCases := []struct {
+		Desc     string
+		Y        Status
+		Expected bool
+	}{
+		{
+			Desc: "clone",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedOrig",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: true,
+		},
+		{
+			Desc: "diff: nodeName",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedOrig",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "NodeFooBar",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pfp Expected",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedDIFF",
+				FingerprintComputed: "PFPComputedOrig",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pfp Computed",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig1",
+						Name:      "Name1",
+					},
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pod count",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig2",
+						Name:      "Name2",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pod values",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				Pods: []NamespacedName{
+					{
+						Namespace: "NSOrig5",
+						Name:      "Name5",
+					},
+					{
+						Namespace: "NSOrigX",
+						Name:      "NameX",
+					},
+				},
+				NodeName: "Node",
+			},
+			Expected: false,
+		},
+		{
+			Desc: "diff: pod missing",
+			Y: Status{
+				FingerprintExpected: "PFPExpectedOrig",
+				FingerprintComputed: "PFPComputedDiff",
+				NodeName:            "Node",
+			},
+			Expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Desc, func(t *testing.T) {
+			got := X.Equal(tc.Y)
+			if got != tc.Expected {
+				t.Fatalf("got=%v expected=%v", got, tc.Expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
grab bag of minor improvements I had in the pipeline for some time.
The most noteworthy is the bump of the golang required version to 1.18, so we can use `any`. Considering we currently are on 1.25, this should not be a bug deal